### PR TITLE
#53: Some CPUs might have gaps in their IDs and querying VirtualBox…

### DIFF
--- a/endpoints/lib/vboxconnector.php
+++ b/endpoints/lib/vboxconnector.php
@@ -3390,9 +3390,10 @@ class vboxconnector {
 		/*
 		 * Processors
 		 */
-		for($i = 0; $i < $host->processorCount; $i++) {
-			// TODO https://github.com/phpvirtualbox/phpvirtualbox/issues/53
-			$response['cpus'][$i] = $host->getProcessorDescription(0);
+		// TODO https://github.com/phpvirtualbox/phpvirtualbox/issues/53
+		$response['cpus'][0] = $host->getProcessorDescription(0);
+		for($i = 1; $i < $host->processorCount; $i++) {
+			$response['cpus'][$i] = $response['cpus'][0];
 		}
 
 		/*

--- a/endpoints/lib/vboxconnector.php
+++ b/endpoints/lib/vboxconnector.php
@@ -3391,7 +3391,8 @@ class vboxconnector {
 		 * Processors
 		 */
 		for($i = 0; $i < $host->processorCount; $i++) {
-			$response['cpus'][$i] = $host->getProcessorDescription($i);
+			// TODO https://github.com/phpvirtualbox/phpvirtualbox/issues/53
+			$response['cpus'][$i] = $host->getProcessorDescription(0);
 		}
 
 		/*


### PR DESCRIPTION
…for processor descriptions for unknown CPU IDs results in an error. Therefore a loop is not the correct strategy to query details of all CPUs, but instead one would need to get all CPU IDs used in the system and iterate those. Even "vboxmanage list hostinfo" seems to be doing that wrong:

https://www.virtualbox.org/ticket/17045

This patch is a quick and dirty WORKAROUND for this problem, because more people seem to be affected by it. Querying only ID 0 will most likely succeed, but even that ID might be missing of course. Additionally, it is very likely that people only use exactly the same CPUs in multi socket systems and with only one socket I couldn't even thing of a reason why the description between the cores of one socket should be different. Keeping the loop is necessary and easy to let phpVirtualBox have available all expected data and performance simply shouldn't be an issue.