### PR TITLE
Add a configuration variable to set the VRDE address

### DIFF
--- a/config.php-example
+++ b/config.php-example
@@ -23,6 +23,8 @@ var $language = 'en';
 
 /* Set the standard VRDE Port Number / Range, e.g. 1010-1020 or 1027 */
 var $vrdeports = '9000-9100';
+/* Set the default VRDE address, e.g. 192.168.1.1 */
+#var $vrdeaddress = '192.168.1.1';
 
 /*
  *

--- a/endpoints/lib/vboxconnector.php
+++ b/endpoints/lib/vboxconnector.php
@@ -3828,6 +3828,7 @@ class vboxconnector {
 					$this->session->machine->VRDEServer->enabled = 1;
 					$this->session->machine->VRDEServer->authTimeout = 5000;
 					$this->session->machine->VRDEServer->setVRDEProperty('TCP/Ports',($this->settings->vrdeports ? $this->settings->vrdeports : '3390-5000'));
+					$this->session->machine->VRDEServer->setVRDEProperty('TCP/Address',($this->settings->vrdeaddress ? $this->settings->vrdeaddress : '127.0.0.1');
 				}
 			} catch (Exception $e) {
 				//Ignore


### PR DESCRIPTION
Currently there is no way to set the address used by virtualbox to bind the VRDE interface,
and sometimes the bind address selected is localhost.  This new configuration parameter allows to define this value globally