### PR TITLE
More user friendly snapshot restore

### DIFF
--- a/panes/tabVMSnapshots.html
+++ b/panes/tabVMSnapshots.html
@@ -567,7 +567,7 @@ $('#vboxPane').on('vmSelectionListChanged',function(){
 	// No single selected VM or it is host
 	} else {
 		// disable tab
-		$('#vboxTabVMConsole').parent().trigger('disableTab', ['vboxTabVMSnapshots']);
+		$('#vboxTabVMSnapshots').parent().trigger('disableTab', ['vboxTabVMSnapshots']);
 		$('#vboxTabVMSnapshots').data('lastVM',0);
 	}
 

--- a/panes/tabVMSnapshots.html
+++ b/panes/tabVMSnapshots.html
@@ -734,10 +734,12 @@ function __vboxTabSnapshotsFill(response) {
 		$('#vboxSnapshotList').vbtree();
 		
 		vboxSnapshotToolbar.enable();
-	
-		$('#vboxSnapshotList').trigger('select');
-	
-		__vboxTabSnapshotTimestamps();	
+		
+		var lastListItem = $(list).find('li.vboxSnapshotCurrentState').last();
+		lastListItem.children().addClass('vboxListItemSelected');
+		$('#vboxSnapshotList').trigger('select',lastListItem);
+		
+		__vboxTabSnapshotTimestamps();
 		
 	});
 

--- a/panes/tabVMSnapshots.html
+++ b/panes/tabVMSnapshots.html
@@ -189,7 +189,10 @@ var vboxSnapshotButtons = [
 
 				
   			};
-  			buttons[trans('Cancel','QIMessageBox')] = function() { $(this).dialog('close'); };
+			buttons[trans('Cancel','QIMessageBox')] = function() {
+				$(this).dialog('close');
+				if(typeof callback == 'function') { callback({success:false,uicancel:true}); }
+			};
   			
   			$('#vboxSnapshotNew').dialog({'closeOnEscape':false,'width':'400px','height':'auto','buttons':buttons,'modal':true,'autoOpen':true,'dialogClass':'vboxDialogContent','title':'<img src="images/vbox/snapshot_take_16px.png" class="vboxDialogTitleIcon" height="16" width="16" /> ' + trans('Take Snapshot of Virtual Machine','VBoxTakeSnapshotDlg')});
   			
@@ -201,7 +204,7 @@ var vboxSnapshotButtons = [
   		'icon' : 'snapshot_restore',
   		'enabled' : function(item) {
   			var vm = vboxChooser.getSingleSelected();
-  			return ( item && $(item).data('vboxSnapshot') && $(item).data('vboxSnapshot') && $(item).data('vboxSnapshot').name && $(item).data('vboxSnapshot').state != 'current' && !vboxVMStates.isRunning(vm) && !vboxVMStates.isPaused(vm));
+			return ( item && $(item).data('vboxSnapshot') && $(item).data('vboxSnapshot') && $(item).data('vboxSnapshot').name && $(item).data('vboxSnapshot').state != 'current');
   		},
   		'click' : function () {
   			
@@ -218,23 +221,77 @@ var vboxSnapshotButtons = [
 				q = trans("<p>You are about to restore snapshot <nobr><b>%1</b></nobr>.</p>" +
                         "<p>You can create a snapshot of the current state of the virtual machine first by checking the box below; " +
                         "if you do not do this the current state will be permanently lost. Do you wish to proceed?</p>",'UIMessageCenter');
-				q += '<p><label><input type="checkbox" id="vboxRestoreSnapshotCreate" checked /> ' + trans('Create a snapshot of the current machine state','UIMessageCenter') + '</label></p>';
+				q += '<p><label><input type="checkbox" id="vboxRestoreSnapshotCreate" checked /> ' + trans('Create a snapshot of the current machine state','UIMessageCenter') + '</label></br>';
+				q += '<label><input type="checkbox" id="vboxRestoreSnapshotAutoStart" '+ (vboxVMStates.isRunning(vm)? 'checked' : '') + ' /> ' + trans('Automatically start the machine after restore','UIMessageCenter') + '</label></p>';
 				
 				buttons[trans('Restore','UIMessageCenter')] = function() {
 
-					var snrestore = function(takeSnapshot){
+					var self = this;
+					var snautostart = function() {
+						var l = new vboxLoader();
+						l.add('machineSetState',function(d){
+							if(!(d && d.success) && errorMsg) {
+								vboxAlert(errorMsg.replace('%1', vm.name));
+								return;
+							}
+							// check for progress operation
+							if(d && d.responseData && d.responseData.progress) {
+								vboxProgress({'progress':d.responseData.progress,'persist':d.persist},function(d){
+									// Do Nothing
+								},'progress_state_restore_90px.png',trans('Power on virtual machine','VBoxSnapshotsWgt'), vm.name);
+								return;
+							}
+						},{'vm':vm.id,'state':'powerUp'});
+
+						l.run();
+					};
+
+					var snrestore = function(autoStart,takeSnapshot){
 						
 						// Don't do anything if taking a snapshot failed
-						if(takeSnapshot && !takeSnapshot.success)
+						if(takeSnapshot && !takeSnapshot.success) {
+							if (takeSnapshot.uicancel)
+								vboxSnapshotButtons[1].click();
 							return;
+						}
 						
+						// Power off VM if needed
+						if(vboxVMStates.isRunning(vm) || vboxVMStates.isPaused(vm)) {
+							var l = new vboxLoader();
+							l.add('machineSetState',function(d){
+								if(!(d && d.success) && errorMsg) {
+									vboxAlert(errorMsg.replace('%1', vm.name));
+									return;
+								}
+								// check for progress operation
+								if(d && d.responseData && d.responseData.progress) {
+									vboxProgress({'progress':d.responseData.progress,'persist':d.persist},function(d){
+										if (d && d.responseData && d.responseData.info) {
+											// when poweroff completed
+											if (d.responseData.info.completed) {
+												// schedule snapshot restore immediate after
+												setTimeout(snrestore.bind(self,autoStart,takeSnapshot),0);
+											}
+										}
+									},'progress_poweroff_90px.png',trans('Power off virtual machine','VBoxSnapshotsWgt'), vm.name);
+								}
+							},{'vm':vm.id,'state':'powerDown'});
+
+							l.run();
+							return;
+						}
+
 			  	  		var l = new vboxLoader();
 			  	  		l.add('snapshotRestore',function(d){
-			  	  			if(d && d.responseData && d.responseData.progress) {
-								vboxProgress({'progress':d.responseData.progress,'persist':d.persist},function(){
-								
-									// Let events get picked up. Nothing to do here
-
+							if(d && d.responseData && d.responseData.progress) {
+								vboxProgress({'progress':d.responseData.progress,'persist':d.persist},function(d){
+									if (d && d.responseData && d.responseData.info) {
+										// when restore completed and auto start is requested
+										if (d.responseData.info.completed && autoStart) {
+											// schedule start immediately
+											setTimeout(snautostart.bind(self), 0);
+										}
+									}
 								},'progress_snapshot_restore_90px.png',trans('Restore Snapshot','VBoxSnapshotsWgt'),
 									vm.name);
 							} else if(d && d.error) {
@@ -246,10 +303,11 @@ var vboxSnapshotButtons = [
 
 					};
 					
+					var vmRestoreAutoStart = $('#vboxRestoreSnapshotAutoStart').prop('checked');
 					if($('#vboxRestoreSnapshotCreate').prop('checked')) {
-						vboxSnapshotButtons[0].click(snrestore);
+						vboxSnapshotButtons[0].click(snrestore.bind(self,vmRestoreAutoStart));
 					} else {
-						snrestore();
+						snrestore(vmRestoreAutoStart);
 					}
 		  	  		$(this).empty().remove();
 				};

--- a/panes/tabVMSnapshots.html
+++ b/panes/tabVMSnapshots.html
@@ -115,11 +115,12 @@ var vboxSnapshotButtons = [
   			}
   			
   			$('#vboxSnapshotNewName').val(trans('Snapshot %1','VBoxSnapshotsWgt').replace('%1',(snMax+1)));
+  			$('#vboxSnapshotNewName').select();
   			$('#vboxSnapshotNewDesc').val('');
   			
   			
   			var buttons = {};
-  			buttons[trans('OK','QIMessageBox')] = function() {
+  			var OKBtn = buttons[trans('OK','QIMessageBox')] = function() {
   				
   				// Get fresh VM state when this is clicked
   				var vm = vboxChooser.getSingleSelected();
@@ -193,6 +194,8 @@ var vboxSnapshotButtons = [
 				$(this).dialog('close');
 				if(typeof callback == 'function') { callback({success:false,uicancel:true}); }
 			};
+  			
+  			$('#vboxSnapshotNewName').off('keypress').on('keypress',function(e) { if (e.keyCode == 13) OKBtn.apply($('#vboxSnapshotNew')); });
   			
   			$('#vboxSnapshotNew').dialog({'closeOnEscape':false,'width':'400px','height':'auto','buttons':buttons,'modal':true,'autoOpen':true,'dialogClass':'vboxDialogContent','title':'<img src="images/vbox/snapshot_take_16px.png" class="vboxDialogTitleIcon" height="16" width="16" /> ' + trans('Take Snapshot of Virtual Machine','VBoxTakeSnapshotDlg')});
   			

--- a/panes/wizardCloneVM.html
+++ b/panes/wizardCloneVM.html
@@ -14,7 +14,7 @@
 	<div class='vboxOptions' style='padding: 6px'>
 		<input type='text' class='vboxText' name='machineCloneName' style='width: 95%' />
 		
-		<p><label><input type='checkbox' class='vboxCheckbox' name='vboxCloneReinitNetwork' />
+		<p><label><input type='checkbox' class='vboxCheckbox' name='vboxCloneReinitNetwork' checked='checked' />
 			<span class='translate'>Reinitialize the MAC address of all network cards</span></label>
 		</p>
 	</div>
@@ -32,10 +32,10 @@
 	<div class='vboxOptions'>
 		<table>
 			<tr style='vertical-align: bottom;'>
-				<td><label><input type='radio' class='vboxRadio' checked='checked' name='vboxCloneType' value='Full' onclick='vboxCloneVMUpdateSteps(this.value)' /> <span class='translate'>Full Clone</span></label></td>
+				<td><label><input type='radio' class='vboxRadio' name='vboxCloneType' value='Full' onclick='vboxCloneVMUpdateSteps(this.value)' /> <span class='translate'>Full Clone</span></label></td>
 			</tr>
 			<tr style='vertical-align: bottom;'>
-				<td><label><input type='radio' class='vboxRadio' name='vboxCloneType' value='Linked' onclick='vboxCloneVMUpdateSteps(this.value)' /> <span class='translate'>Linked Clone</span></label></td>
+				<td><label><input type='radio' class='vboxRadio' checked='checked' name='vboxCloneType' value='Linked' onclick='vboxCloneVMUpdateSteps(this.value)' /> <span class='translate'>Linked Clone</span></label></td>
 			</tr>		
 		</table>
 	</div>
@@ -97,6 +97,9 @@ $('#wizardCloneVMStep1').on('show',function(e,wiz){
 
 	$(document.forms['frmwizardCloneVM'].elements.machineCloneName).focus();
 	document.forms['frmwizardCloneVM'].elements.machineCloneName.value = trans('%1 Clone','UIWizardCloneVMPage1').replace('%1',wiz.args.vm.name);
+
+	var inputBox = $('#wizardCloneVMStep1').find('input.vboxText').select();
+	setTimeout(inputBox.focus.bind(inputBox),10);
 });
 
 /* When going to step2, make sure a name is entered */

--- a/panes/wizardCloneVMAdvanced.html
+++ b/panes/wizardCloneVMAdvanced.html
@@ -21,10 +21,10 @@
 				<div class='vboxOptions'>
 					<table style='margin-top: 8px'>
 						<tr style='vertical-align: bottom;'>
-							<td><label><input type='radio' class='vboxRadio' checked='checked' name='vboxCloneType' value='Full' onclick='vboxCloneVMUpdateSteps(this.value)' /> <span class='translate'>Full Clone</span></label></td>
+							<td><label><input type='radio' class='vboxRadio' name='vboxCloneType' value='Full' onclick='vboxCloneVMUpdateSteps(this.value)' /> <span class='translate'>Full Clone</span></label></td>
 						</tr>
 						<tr style='vertical-align: bottom;'>
-							<td><label><input type='radio' class='vboxRadio' name='vboxCloneType' value='Linked' onclick='vboxCloneVMUpdateSteps(this.value)' /> <span class='translate'>Linked Clone</span></label></td>
+							<td><label><input type='radio' class='vboxRadio' checked='checked' name='vboxCloneType' value='Linked' onclick='vboxCloneVMUpdateSteps(this.value)' /> <span class='translate'>Linked Clone</span></label></td>
 						</tr>		
 					</table>
 				</div>
@@ -48,7 +48,7 @@
 		</tr>
 	</table>
 
-	<p><label><input type='checkbox' class='vboxCheckbox' name='vboxCloneReinitNetwork' />
+	<p><label><input type='checkbox' class='vboxCheckbox' name='vboxCloneReinitNetwork' checked='checked' />
 		<span class='translate'>Reinitialize the MAC address of all network cards</span></label>
 	</p>
 </div>
@@ -82,6 +82,9 @@ $('#wizardCloneVMStep1').on('show',function(e,wiz){
 	$(document.forms['frmwizardCloneVM'].elements.machineCloneName).focus();
 
 	document.forms['frmwizardCloneVM'].elements.machineCloneName.value = trans('%1 Clone','UIWizardCloneVMPage1').replace('%1',wiz.args.vm.name);
+
+	var inputBox = $('#wizardCloneVMStep1').find('input.vboxText').select();
+	setTimeout(inputBox.focus.bind(inputBox),10);
 });
 
 


### PR DESCRIPTION
This patch improves several operational experience wrt. snapshot restore:

1. Allows restore of VM in non-stopped state, automatically power off the VM in the process
2. Option to automatically power on the VM after restore (default value based on current VM state)
3. When restore triggered new snapshot dialog, and you realized you don't need a new snapshot, cancelling the new snapshot dialog will automatically re-open the restore dialog again