### PR TITLE
Add Discard (TRIM) option and NVME storage controller

### DIFF
--- a/endpoints/lib/vboxServiceWrappers.php
+++ b/endpoints/lib/vboxServiceWrappers.php
@@ -16269,8 +16269,8 @@ class DataFlagsCollection extends VBox_EnumCollection
  */
 class MediumFormatCapabilities extends VBox_Enum
 {
-    public $NameMap = array(0x01 => 'Uuid', 0x02 => 'CreateFixed', 0x04 => 'CreateDynamic', 0x08 => 'CreateSplit2G', 0x10 => 'Differencing', 0x20 => 'Asynchronous', 0x40 => 'File', 0x80 => 'Properties', 0x100 => 'TcpNetworking', 0x200 => 'VFS', 0x3FF => 'CapabilityMask');
-    public $ValueMap = array('Uuid' => 0x01, 'CreateFixed' => 0x02, 'CreateDynamic' => 0x04, 'CreateSplit2G' => 0x08, 'Differencing' => 0x10, 'Asynchronous' => 0x20, 'File' => 0x40, 'Properties' => 0x80, 'TcpNetworking' => 0x100, 'VFS' => 0x200, 'CapabilityMask' => 0x3FF);
+    public $NameMap = array(0x01 => 'Uuid', 0x02 => 'CreateFixed', 0x04 => 'CreateDynamic', 0x08 => 'CreateSplit2G', 0x10 => 'Differencing', 0x20 => 'Asynchronous', 0x40 => 'File', 0x80 => 'Properties', 0x100 => 'TcpNetworking', 0x200 => 'VFS', 0x400 => 'Discard', 0x800 => 'Preferred', 0xFFF => 'CapabilityMask');
+    public $ValueMap = array('Uuid' => 0x01, 'CreateFixed' => 0x02, 'CreateDynamic' => 0x04, 'CreateSplit2G' => 0x08, 'Differencing' => 0x10, 'Asynchronous' => 0x20, 'File' => 0x40, 'Properties' => 0x80, 'TcpNetworking' => 0x100, 'VFS' => 0x200, 'Discard' => 0x400, 'Preferred' => 0x800, 'CapabilityMask' => 0xFFF);
 }
 
 /**
@@ -16592,8 +16592,8 @@ class ReasonCollection extends VBox_EnumCollection
  */
 class StorageBus extends VBox_Enum
 {
-    public $NameMap = array(0 => 'Null', 1 => 'IDE', 2 => 'SATA', 3 => 'SCSI', 4 => 'Floppy', 5 => 'SAS', 6 => 'USB');
-    public $ValueMap = array('Null' => 0, 'IDE' => 1, 'SATA' => 2, 'SCSI' => 3, 'Floppy' => 4, 'SAS' => 5, 'USB' => 6);
+    public $NameMap = array(0 => 'Null', 1 => 'IDE', 2 => 'SATA', 3 => 'SCSI', 4 => 'Floppy', 5 => 'SAS', 6 => 'USB', 7 => 'PCIe');
+    public $ValueMap = array('Null' => 0, 'IDE' => 1, 'SATA' => 2, 'SCSI' => 3, 'Floppy' => 4, 'SAS' => 5, 'USB' => 6, 'PCIe' => 7);
 }
 
 /**
@@ -16609,8 +16609,8 @@ class StorageBusCollection extends VBox_EnumCollection
  */
 class StorageControllerType extends VBox_Enum
 {
-    public $NameMap = array(0 => 'Null', 1 => 'LsiLogic', 2 => 'BusLogic', 3 => 'IntelAhci', 4 => 'PIIX3', 5 => 'PIIX4', 6 => 'ICH6', 7 => 'I82078', 8 => 'LsiLogicSas', 9 => 'USB');
-    public $ValueMap = array('Null' => 0, 'LsiLogic' => 1, 'BusLogic' => 2, 'IntelAhci' => 3, 'PIIX3' => 4, 'PIIX4' => 5, 'ICH6' => 6, 'I82078' => 7, 'LsiLogicSas' => 8, 'USB' => 9);
+    public $NameMap = array(0 => 'Null', 1 => 'LsiLogic', 2 => 'BusLogic', 3 => 'IntelAhci', 4 => 'PIIX3', 5 => 'PIIX4', 6 => 'ICH6', 7 => 'I82078', 8 => 'LsiLogicSas', 9 => 'USB', 10 => 'NVMe');
+    public $ValueMap = array('Null' => 0, 'LsiLogic' => 1, 'BusLogic' => 2, 'IntelAhci' => 3, 'PIIX3' => 4, 'PIIX4' => 5, 'ICH6' => 6, 'I82078' => 7, 'LsiLogicSas' => 8, 'USB' => 9, 'NVMe' => 10);
 }
 
 /**

--- a/js/phpvirtualbox.js
+++ b/js/phpvirtualbox.js
@@ -2430,7 +2430,7 @@ var vboxMedia = {
 	},
 	
 	/**
-	 * Return true if a medium format supports
+	 * Return true if a medium format supports Split2G
 	 */
 	formatSupportsSplit: function(format) {
 		
@@ -2441,6 +2441,23 @@ var vboxMedia = {
 		for(var i = 0; i < mfs.length; i++) {
 			if(mfs[i].id.toLowerCase() == format) {
 				return (jQuery.inArray('CreateSplit2G',mfs[i].capabilities) > -1);
+			}
+		}
+		return false;
+	},
+
+		/**
+	 * Return true if a medium format supports Discard
+	 */
+	formatSupportsDiscard: function(format) {
+
+		var format = format.toLowerCase();
+
+		var mfs = $('#vboxPane').data('vboxSystemProperties').mediumFormats;
+
+		for(var i = 0; i < mfs.length; i++) {
+			if(mfs[i].id.toLowerCase() == format) {
+				return (jQuery.inArray('Discard',mfs[i].capabilities) > -1);
 			}
 		}
 		return false;
@@ -4747,7 +4764,13 @@ var vboxStorage = {
                         attrib: 'ignoreFlush',
                         runningEnabled: true,
 	                });
-	            }
+	            };
+	            if($('#vboxPane').data('vboxConfig').enableAdvancedConfig&&vboxMedia.formatSupportsDiscard(ma.medium.format)) {
+	                opts[opts.length]={
+                        label: 'Support Discard(TRIM)',
+                        attrib: 'discard',
+	                };
+	            };
 	            return opts;
 	        case 'DVD':
 	            // Host drive
@@ -4881,18 +4904,34 @@ var vboxStorage = {
 	},
 	
 	USB: {
-        maxPortCount: 8,
-        maxDevicesPerPortCount: 1,
-        types: ['USB'],
-        driveTypes: ['dvd','disk'],
-        slotName: function(p,d) { return trans('USB Port %1','VBoxGlobal', null, 'StorageSlot').replace('%1',p); },
-        slots: function() {
-            var s = {};
-            for(var i = 0; i < 8; i++) {
-                s[i+'-0'] = trans('USB Port %1','VBoxGlobal', null, 'StorageSlot').replace('%1',i);
-            }
-            return s;
-        }
+		maxPortCount: 8,
+		maxDevicesPerPortCount: 1,
+	types: ['USB'],
+		driveTypes: ['dvd','disk'],
+		slotName: function(p,d) { return trans('USB Port %1','VBoxGlobal', null, 'StorageSlot').replace('%1',p); },
+		slots: function() {
+			var s = {};
+			for(var i = 0; i < 8; i++) {
+				s[i+'-0'] = trans('USB Port %1','VBoxGlobal', null, 'StorageSlot').replace('%1',i);
+			}
+		return s;
+		}
+	},
+
+PCIe: {
+		maxPortCount: 255,
+		maxDevicesPerPortCount: 1,
+		types: ['NVMe'],
+		driveTypes: ['disk'],
+		slotName: function(p,d) { return trans('NVMe Port %1','VBoxGlobal', null, 'StorageSlot').replace('%1',p); },
+		slots: function() {
+			var s = {};
+			for(var i = 0; i < 8; i++) {
+				s[i+'-0'] = trans('NVMe Port %1','VBoxGlobal', null, 'StorageSlot').replace('%1',i);
+			}
+			return s;
+		},
+	displayInherit: 'IDE'
 	}
 };
 

--- a/js/phpvirtualbox.js
+++ b/js/phpvirtualbox.js
@@ -4918,7 +4918,7 @@ var vboxStorage = {
 		}
 	},
 
-PCIe: {
+	PCIe: {
 		maxPortCount: 255,
 		maxDevicesPerPortCount: 1,
 		types: ['NVMe'],

--- a/js/phpvirtualbox.js
+++ b/js/phpvirtualbox.js
@@ -4767,7 +4767,7 @@ var vboxStorage = {
 	            };
 	            if($('#vboxPane').data('vboxConfig').enableAdvancedConfig&&vboxMedia.formatSupportsDiscard(ma.medium.format)) {
 	                opts[opts.length]={
-                        label: 'Support Discard(TRIM)',
+                        label: 'Support Discard (TRIM)',
                         attrib: 'discard',
 	                };
 	            };

--- a/panes/settingsStorage.html
+++ b/panes/settingsStorage.html
@@ -945,7 +945,7 @@ function vboxSettingsSelectController(tbl) {
     $('#vboxSettingsHDInfo').css('display','none');
     
     // Show SATA port count
-    if(busType == 'SATA') {
+    if((busType == 'SATA')||(busType == 'PCIe')) {
 	    $(document.forms['frmVboxSettings'].vboxSettingsControllerPortCount).val($(tbl).data('controller').portCount);
 	   	$('#vboxSettingsControllerPortCountRow').css('display','');
 	} else {


### PR DESCRIPTION
This pull request adds NVME as available storage controller and the ability to select Discard (TRIM). Discard requires a VDI to be set as non-rotational (SSD). This will allow a VDI to shrink on the host if trim has been issued inside the guest. This would finally make an end to using zerofree, sdelete or dd to fill up the disk with zeroes before shutting down the VM and using vboxmanage modifymedium diskname.vdi --compact - which is a task that drives people away from VirtualBox.

Coded by @pasha1st - his pull request https://github.com/phpvirtualbox/phpvirtualbox/pull/167 got legitimately rejected due to several issues so I am lending a helping hand and split this into multiple pull requests. This needs tested and finally merged, we need to move forward.