### PR TITLE
Change SCSI maxPortCount to 15 (by pasha1st)

### DIFF
--- a/js/phpvirtualbox.js
+++ b/js/phpvirtualbox.js
@@ -4838,7 +4838,7 @@ var vboxStorage = {
 	},
 		
 	SCSI: {
-		maxPortCount: 16,
+		maxPortCount: 15,
 		maxDevicesPerPortCount: 1,
 		driveTypes: ['dvd','disk'],
 		types: ['LsiLogic','BusLogic'],


### PR DESCRIPTION
This pull request changes the SCSI maxPortCount from 16 to 15, as documented by Oracle: "Primarily for compatibility with other virtualization software, Oracle VM VirtualBox optionally supports LSI Logic and BusLogic SCSI controllers, to each of which up to 15 virtual hard disks can be attached." at https://www.virtualbox.org/manual/ch05.html

Fixed by @pasha1st - his pull request https://github.com/phpvirtualbox/phpvirtualbox/pull/167 got legitimately rejected due to several issues so I am lending a helping hand and split this into multiple pull requests. This needs tested and finally merged, we need to move forward.