### PR TITLE
Prevent access to .git/ directory

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -1,0 +1,1 @@
+RedirectMatch 404 /\.git


### PR DESCRIPTION
I installed phpVirtualBox from source and noticed that the .git/ directory was available publicly via HTTP. As this could be a security vulnerability, I figured it would be good to make sure to blacklist everything in .git/.