### PR TITLE
Compatibility update for PHP 8.0.13

### DIFF
--- a/endpoints/lib/language.php
+++ b/endpoints/lib/language.php
@@ -72,7 +72,7 @@ class __vbox_language {
 
 		$xmlObj = simplexml_load_string(@file_get_contents(VBOX_BASE_LANG_DIR.'/'.$lang.'.xml'));
 		$arrXml = $this->objectsIntoArray($xmlObj);
-
+		if(!array_key_exists('context',$arrXml)) return;
 		$lang = array();
 		if(!@$arrXml['context'][0]) $arrXml['context'] = array($arrXml['context']);
 		foreach($arrXml['context'] as $c) {


### PR DESCRIPTION
Without checking for key 'context' in $arrXml, application will throw an error message when english language is selected.